### PR TITLE
add initial image building, test via travis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+ci-bundle

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ci-bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: required
+services:
+  - docker
+
+script: bin/ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# jdk-9 doesn't seem to work as of onebusaway-application-modules as of 8062291,
+# fails to build bundles
+FROM maven:3.5.2-jdk-8 as build
+
+RUN git clone --depth 1 https://github.com/OneBusAway/onebusaway-application-modules.git /app
+RUN cd /app && mvn install -Dlicense.skip=true -Dmaven.test.skip=true --quiet
+
+FROM tomcat:8
+
+ENV JAVA_OPTS="-Xss4m"
+
+RUN mkdir /app
+COPY --from=build /app/onebusaway-transit-data-federation-builder/target/onebusaway-transit-data-federation-builder-2.0.0-SNAPSHOT-withAllDependencies.jar /app
+COPY --from=build /app/onebusaway-transit-data-federation-webapp/target/onebusaway-transit-data-federation-webapp.war /app
+RUN unzip -q /app/onebusaway-transit-data-federation-webapp.war -d /usr/local/tomcat/webapps/onebusaway-transit-data-federation-webapp
+ADD config/onebusaway-transit-data-federation-webapp-data-sources.xml /usr/local/tomcat/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/classes/data-sources.xml

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+docker build -t oba-ci .
+
+rm -rf ci-bundle
+mkdir ci-bundle
+
+echo "=== building bundle"
+if ! docker run --rm -v "$(pwd)/ci-bundle:/bundle" oba-ci bash -c 'cd /bundle && \
+       curl --max-time 10 --retry 3 --fail -L -o /tmp/data.zip http://gtfs.halifax.ca/static/google_transit.zip && \
+       java -Xss4m -Xmx3G \
+            -jar /app/onebusaway-transit-data-federation-builder-2.0.0-SNAPSHOT-withAllDependencies.jar \
+            /tmp/data.zip .' >/tmp/build-bundle.out 2>&1; then
+    echo " ! bundle building failed"
+    echo "=== bundle build output"
+    tail -n1000 /tmp/build-bundle.out
+    exit 1
+fi
+
+echo "=== running server"
+docker run --name oba-ci -d --rm -v "$(pwd)/ci-bundle:/bundle" -p 8888:8080 oba-ci
+
+echo "=== waiting for successful onebusaway-transit-data-federation-webapp request"
+for i in $(seq 1 60); do
+    curl --max-time 3 --fail http://localhost:8888/onebusaway-transit-data-federation-webapp/ && exit 0
+    sleep 1
+done
+
+echo " ! request to onebusaway-transit-data-federation-webapp never succeeded"
+
+echo "=== docker logs"
+docker logs oba-ci
+
+# TODO: tomcat logs
+
+exit 1

--- a/config/onebusaway-transit-data-federation-webapp-data-sources.xml
+++ b/config/onebusaway-transit-data-federation-webapp-data-sources.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xmlns:context="http://www.springframework.org/schema/context"
+xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+    <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+        <property name="driverClassName" value="org.hsqldb.jdbcDriver" />
+        <property name="url" value="jdbc:hsqldb:file:/bundle/org_onebusaway_transit_data" />
+        <property name="username" value="sa" />
+        <property name="password" value="" />
+    </bean>
+    <bean class="org.onebusaway.container.spring.SystemPropertyOverrideConfigurer">
+      <property name="order" value="-2" />
+      <property name="properties">
+          <props>
+              <prop key="bundlePath">/var/lib/obanyc/no-such-dir</prop>
+         </props>
+      </property>
+    </bean>
+    <bean id="httpServiceClient" class="org.onebusaway.transit_data_federation.util.HttpServiceClientImpl" >
+      <constructor-arg type="java.lang.String" value="localhost"/>
+      <constructor-arg type="java.lang.Integer" value="9999" />
+      <constructor-arg type="java.lang.String" value="/api/" />
+    </bean>
+    <bean id="bundleManagementService" class="org.onebusaway.transit_data_federation.impl.bundle.BundleManagementServiceImpl">
+      <property name="bundleStoreRoot" value="/bundle" />
+      <property name="standaloneMode" value="true" />
+    </bean>
+</beans>


### PR DESCRIPTION
Gets an image running just onebusaway-transit-data-federation-webapp
which, when tested via travis, successfully responds to an http
request to /onebusaway-transit-data-federation-webapp/.

Fixes #2 