### PR TITLE
add enterprise-acta-webapp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,8 @@ ADD config/onebusaway-transit-data-federation-webapp-data-sources.xml /usr/local
 COPY --from=build /app/onebusaway-api-webapp/target/onebusaway-api-webapp.war /app
 RUN unzip -q /app/onebusaway-api-webapp.war -d /usr/local/tomcat/webapps/onebusaway-api-webapp
 ADD config/onebusaway-api-webapp-data-sources.xml /usr/local/tomcat/webapps/onebusaway-api-webapp/WEB-INF/classes/data-sources.xml
+
+RUN rm -rf /usr/local/tomcat/webapps/ROOT
+COPY --from=build /app/onebusaway-enterprise-acta-webapp/target/onebusaway-enterprise-acta-webapp.war /app
+RUN unzip -q /app/onebusaway-enterprise-acta-webapp.war -d /usr/local/tomcat/webapps/ROOT
+ADD config/onebusaway-enterprise-acta-webapp-data-sources.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/classes/data-sources.xml

--- a/bin/ci
+++ b/bin/ci
@@ -20,7 +20,10 @@ check_url() {
 
     echo "=== waiting for successful $name request"
     for i in $(seq 1 20); do
-        curl --max-time 3 --fail "$url" && return 0
+        if curl --max-time 3 --fail "$url"; then
+            echo # in case the api response didn't have a newline
+            return 0
+        fi
         sleep 1
     done
 

--- a/bin/ci
+++ b/bin/ci
@@ -19,7 +19,7 @@ check_url() {
     url="$2"
 
     echo "=== waiting for successful $name request"
-    for i in $(seq 1 60); do
+    for i in $(seq 1 20); do
         curl --max-time 3 --fail "$url" && return 0
         sleep 1
     done
@@ -69,3 +69,4 @@ docker run --name oba-ci -d --rm -v "$(pwd)/ci-bundle:/bundle" --link oba-postgr
 
 check_url onebusaway-transit-data-federation-webapp http://localhost:8888/onebusaway-transit-data-federation-webapp/
 check_url onebusaway-api-webapp 'http://localhost:8888/onebusaway-api-webapp/api/where/agency/Halifax.json?key=TEST'
+check_url onebusaway-enterprise-acta-webapp http://localhost:8888/routes

--- a/config/onebusaway-enterprise-acta-webapp-data-sources.xml
+++ b/config/onebusaway-enterprise-acta-webapp-data-sources.xml
@@ -14,7 +14,6 @@
   <bean id="serviceAreaServiceImpl" class="org.onebusaway.presentation.impl.ServiceAreaServiceImpl">
     <property name="calculateDefaultBoundsFromAgencyCoverage" value="true" />
   </bean>
-  <bean id="externalGeocoderImpl" class="org.onebusaway.geocoder.impl.GoogleGeocoderImpl" />
   <bean class="org.onebusaway.container.spring.PropertyOverrideConfigurer">
     <property name="properties">
       <props>
@@ -25,4 +24,6 @@
   <bean id="siriCacheService" class="org.onebusaway.presentation.services.cachecontrol.SiriCacheServiceImpl">
     <property name="disabled" value="true" />
   </bean>
+  <bean id="searchServiceImpl" class="org.onebusaway.presentation.impl.search.SearchServiceImpl" />
+  <bean id="enterpriseGeocoderImpl" class="org.onebusaway.geocoder.enterprise.impl.EnterpriseGoogleGeocoderImpl" />
 </beans>

--- a/config/onebusaway-enterprise-acta-webapp-data-sources.xml
+++ b/config/onebusaway-enterprise-acta-webapp-data-sources.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:aop="http://www.springframework.org/schema/aop" xmlns:context="http://www.springframework.org/schema/context" xmlns:jee="http://www.springframework.org/schema/jee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd         http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd         http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee-3.0.xsd">
+  <bean id="transitDataService" class="org.springframework.remoting.caucho.HessianProxyFactoryBean">
+    <property name="serviceUrl" value="http://localhost:8080/onebusaway-transit-data-federation-webapp/remoting/transit-data-service" />
+    <property name="serviceInterface" value="org.onebusaway.transit_data.services.TransitDataService" />
+  </bean>
+  <!-- Database Configuration -->
+  <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+    <property name="driverClassName" value="org.postgresql.Driver" />
+    <property name="url" value="jdbc:postgresql://postgres/onebusaway" />
+    <property name="username" value="postgres" />
+  </bean>
+  <alias name="dataSource" alias="mutableDataSource" />
+  <bean id="serviceAreaServiceImpl" class="org.onebusaway.presentation.impl.ServiceAreaServiceImpl">
+    <property name="calculateDefaultBoundsFromAgencyCoverage" value="true" />
+  </bean>
+  <bean id="externalGeocoderImpl" class="org.onebusaway.geocoder.impl.GoogleGeocoderImpl" />
+  <bean class="org.onebusaway.container.spring.PropertyOverrideConfigurer">
+    <property name="properties">
+      <props>
+        <prop key="cacheManager.cacheManagerName">org.onebusaway.nyc_webapp.cacheManager</prop>
+      </props>
+    </property>
+  </bean>
+  <bean id="siriCacheService" class="org.onebusaway.presentation.services.cachecontrol.SiriCacheServiceImpl">
+    <property name="disabled" value="true" />
+  </bean>
+</beans>


### PR DESCRIPTION
Adds `onebusaway-enterprise-acta-webapp` (i.e., v2 of the web UI) to the mix.

For deployments of v2 interface see:
* Tampa - http://tampa.onebusaway.org/enterprise/
* Puget Sound - http://pugetsound.onebusaway.org/enterprise/

Some configuration instructions:
https://github.com/OneBusAway/onebusaway-application-modules/wiki/Enterprise-Webapp-Configuration