### PR TITLE
Add Docker Compose configuration, and improve README documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ci-bundle
 bundle
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ci-bundle
+bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Maven fails to build under JDK 9
+# Maven fails to build the OBA modules under JDK 9
 FROM maven:3-jdk-8 AS build
 
 RUN git clone \
@@ -17,7 +17,9 @@ ENV JAVA_OPTS="-Xss4m"
 
 RUN mkdir /app
 
-ADD https://jdbc.postgresql.org/download/postgresql-42.2.6.jar /usr/local/tomcat/lib
+RUN wget \
+	--directory-prefix /usr/local/tomcat/lib \
+	https://jdbc.postgresql.org/download/postgresql-42.2.6.jar
 
 COPY --from=build /app/onebusaway-transit-data-federation-builder/target/onebusaway-transit-data-federation-builder-2.0.0-SNAPSHOT-withAllDependencies.jar /app
 
@@ -26,14 +28,14 @@ RUN unzip \
 	-q \
 	/tmp/onebusaway-transit-data-federation-webapp.war \
 	-d /usr/local/tomcat/webapps/onebusaway-transit-data-federation-webapp
-ADD ./config/onebusaway-transit-data-federation-webapp-data-sources.xml /usr/local/tomcat/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/classes/data-sources.xml
+COPY ./config/onebusaway-transit-data-federation-webapp-data-sources.xml /usr/local/tomcat/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/classes/data-sources.xml
 
 COPY --from=build /app/onebusaway-api-webapp/target/onebusaway-api-webapp.war /tmp
 RUN unzip \
 	-q \
 	/tmp/onebusaway-api-webapp.war \
 	-d /usr/local/tomcat/webapps/onebusaway-api-webapp
-ADD ./config/onebusaway-api-webapp-data-sources.xml /usr/local/tomcat/webapps/onebusaway-api-webapp/WEB-INF/classes/data-sources.xml
+COPY ./config/onebusaway-api-webapp-data-sources.xml /usr/local/tomcat/webapps/onebusaway-api-webapp/WEB-INF/classes/data-sources.xml
 
 RUN rm -rf /usr/local/tomcat/webapps/ROOT
 COPY --from=build /app/onebusaway-enterprise-acta-webapp/target/onebusaway-enterprise-acta-webapp.war /tmp
@@ -41,4 +43,4 @@ RUN unzip \
 	-q \
 	/tmp/onebusaway-enterprise-acta-webapp.war \
 	-d /usr/local/tomcat/webapps/ROOT
-ADD ./config/onebusaway-enterprise-acta-webapp-data-sources.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/classes/data-sources.xml
+COPY ./config/onebusaway-enterprise-acta-webapp-data-sources.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/classes/data-sources.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
-# jdk-9 doesn't seem to work as of onebusaway-application-modules as of 8062291,
-# fails to build bundles
-FROM maven:3.5.2-jdk-8 as build
+# Maven fails to build under JDK 9
+FROM maven:3-jdk-8 AS build
 
-RUN git clone --depth 1 https://github.com/OneBusAway/onebusaway-application-modules.git /app
-RUN cd /app && mvn install -Dlicense.skip=true -Dmaven.test.skip=true --quiet
+RUN git clone \
+	--depth 1 \
+	https://github.com/OneBusAway/onebusaway-application-modules.git \
+	/app
+WORKDIR /app
+RUN mvn install \
+	--quiet \
+	-D license.skip=true \
+	-D maven.test.skip=true
 
 FROM tomcat:8
 
@@ -11,19 +17,28 @@ ENV JAVA_OPTS="-Xss4m"
 
 RUN mkdir /app
 
-ADD https://jdbc.postgresql.org/download/postgresql-42.2.1.jar /usr/local/tomcat/lib
+ADD https://jdbc.postgresql.org/download/postgresql-42.2.6.jar /usr/local/tomcat/lib
 
 COPY --from=build /app/onebusaway-transit-data-federation-builder/target/onebusaway-transit-data-federation-builder-2.0.0-SNAPSHOT-withAllDependencies.jar /app
 
-COPY --from=build /app/onebusaway-transit-data-federation-webapp/target/onebusaway-transit-data-federation-webapp.war /app
-RUN unzip -q /app/onebusaway-transit-data-federation-webapp.war -d /usr/local/tomcat/webapps/onebusaway-transit-data-federation-webapp
-ADD config/onebusaway-transit-data-federation-webapp-data-sources.xml /usr/local/tomcat/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/classes/data-sources.xml
+COPY --from=build /app/onebusaway-transit-data-federation-webapp/target/onebusaway-transit-data-federation-webapp.war /tmp
+RUN unzip \
+	-q \
+	/tmp/onebusaway-transit-data-federation-webapp.war \
+	-d /usr/local/tomcat/webapps/onebusaway-transit-data-federation-webapp
+ADD ./config/onebusaway-transit-data-federation-webapp-data-sources.xml /usr/local/tomcat/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/classes/data-sources.xml
 
-COPY --from=build /app/onebusaway-api-webapp/target/onebusaway-api-webapp.war /app
-RUN unzip -q /app/onebusaway-api-webapp.war -d /usr/local/tomcat/webapps/onebusaway-api-webapp
-ADD config/onebusaway-api-webapp-data-sources.xml /usr/local/tomcat/webapps/onebusaway-api-webapp/WEB-INF/classes/data-sources.xml
+COPY --from=build /app/onebusaway-api-webapp/target/onebusaway-api-webapp.war /tmp
+RUN unzip \
+	-q \
+	/tmp/onebusaway-api-webapp.war \
+	-d /usr/local/tomcat/webapps/onebusaway-api-webapp
+ADD ./config/onebusaway-api-webapp-data-sources.xml /usr/local/tomcat/webapps/onebusaway-api-webapp/WEB-INF/classes/data-sources.xml
 
 RUN rm -rf /usr/local/tomcat/webapps/ROOT
-COPY --from=build /app/onebusaway-enterprise-acta-webapp/target/onebusaway-enterprise-acta-webapp.war /app
-RUN unzip -q /app/onebusaway-enterprise-acta-webapp.war -d /usr/local/tomcat/webapps/ROOT
-ADD config/onebusaway-enterprise-acta-webapp-data-sources.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/classes/data-sources.xml
+COPY --from=build /app/onebusaway-enterprise-acta-webapp/target/onebusaway-enterprise-acta-webapp.war /tmp
+RUN unzip \
+	-q \
+	/tmp/onebusaway-enterprise-acta-webapp.war \
+	-d /usr/local/tomcat/webapps/ROOT
+ADD ./config/onebusaway-enterprise-acta-webapp-data-sources.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/classes/data-sources.xml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,52 @@
-# OneBusAway Docker Packaging
+# OneBusAway v2 Docker Packaging
 
-This repository contains scripts and configuration for building the
+This repository contains scripts and configuration for building version 2 of the
 [OneBusAway Application Suite](https://github.com/OneBusAway/onebusaway-application-modules)
 for use with [Docker](https://www.docker.com/).
 
-Work is still underway, there will be more information here soon.
+## CI and functionality demonstration
+
+A demonstration of the functionality using only basic Docker can be seen by executing the `./bin/ci` script. This demo runs with a GTFS feed from Halifax, Nova Scotia.
+
+## Running locally
+
+To build bundles and run the webapp server with your own GTFS feed, use the [Docker Compose](https://docs.docker.com/compose/) services in this repository.
+
+### Building bundles
+
+To build a bundle, use the `build-bundle` service:
+
+```bash
+cp /PATH/TO/YOUR_TRANSIT_GTFS.zip ./bundle/YOUR_TRANSIT_GTFS.zip
+docker-compose up build-bundle
+```
+
+This process will create all necessary bundle files and metadata, and all will be accessible in your local repo's `./bundle` directory.
+
+### Running the OneBusAway server
+
+Once you have a built OBA bundle inside `./bundle`, you can run the OBA server and make it accessible on your host machine with:
+
+```bash
+docker-compose up oba
+```
+
+You will then have three webapps available:
+
+- API, hosted at `http://localhost:8888/onebusaway-api-webapp/api?key=TEST`
+  - an example call could be to `http://localhost:8888/onebusaway-api-webapp/api/where/agencies-with-coverage.json?key=TEST`, which should show metadata about the agency you loaded
+  - the test/demo API key is set in `./config/onebusaway-api-webapp-data-sources.xml`; this can be changed as needed, and should be deleted before use in production
+- Transit Data Federation, hosted at `http://localhost:8888/onebusaway-transit-data-federation-webapp/`
+- Enterprise Interface, hosted at `http://localhost:8888/routes/index`
+
+When done using this web server, you can use the shell-standard `^C` to exit out and turn it off. If issues persist across runs, you can try using `docker-compose down -v` and then `docker-compose up oba` to refresh the Docker containers and services.
+
+### Inspecting the database
+
+The Postgres 10 database Docker Compose service should remain up after a call of `docker-compose up oba`. Otherwise, you can always invoke it using `docker-compose up postgres`.
+
+A database port is open to your host machine, so you can connect to it programmatically using `psql`:
+
+```bash
+psql postgres://postgres@localhost:5433/onebusaway
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3"
+
+services:
+  build-bundle:
+    build: .
+    volumes:
+      # Place a single GTFS ZIP file in the `./bundle`
+      # directory, then run this service to build a
+      # bundle from it, output to the same directory
+      - ./bundle:/bundle
+    # Command needs to be wrapped in `sh`, since otherwise
+    # the subshell command doesn't work
+    # Also, the JAR must be executed from within the same
+    # directory as the bundle, or else some necessary files
+    # are not generated
+    command: ["sh", "-c", "cd /bundle && java -Xss4m -Xmx3G -jar /app/onebusaway-transit-data-federation-builder-2.0.0-SNAPSHOT-withAllDependencies.jar $$(ls /bundle/*.zip) ."]
+
+  # The `oba` service expects this service to be addressed
+  # as `postgres`, so this name cannot be changed
+  postgres:
+    image: "postgres:10"
+    environment:
+      # These are the settings that the OBA image expects
+      # There is no password
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=onebusaway
+    ports:
+      # Use a different port than default, in case the host
+      # is running its own Postgres instance
+      # Can connect to this database from the host, using
+      # psql postgres://postgres@localhost:5433/onebusaway
+      - "5433:5432"
+
+  oba:
+    depends_on:
+      # Automatically bring up the database service first
+      - postgres
+    build: .
+    volumes:
+      # Share the host's `bundle` directory with the
+      # filesystem of the OBA service
+      - ./bundle:/bundle
+    ports:
+      # Access the webapp on your host machine at a path like
+      # http://localhost:8888/onebusaway-api-webapp/api/where/agency/${YOUR_AGENCY}.json?key=TEST
+      - "8888:8080"


### PR DESCRIPTION
We've taken the CI script that y'all had built, and used that set up to inform a Docker Compose file. This helps to simplify the local setup, usage, and deployment. To accompany, we wrote this usage up in the README.

Per Docker documentation, we also tweaked some of the directives in the Dockerfile, and split some of the commands into multi-line for better readability. The core tasks of the Dockerfile remain unchanged from your original version.