### PR TITLE
bin/ci: pass POSTGRES_HOST_AUTH_METHOD=trust to postgres container

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -50,7 +50,9 @@ if ! docker run --rm -v "$(pwd)/ci-bundle:/bundle" oba-ci bash -c 'cd /bundle &&
 fi
 
 echo "=== running postgres"
-docker run --name oba-postgres -d --rm postgres:10
+# Note that POSTGRES_HOST_AUTH_METHOD=trust is highly insecure and should
+# never be used in production.
+docker run --name oba-postgres -d -e POSTGRES_HOST_AUTH_METHOD=trust --rm postgres:10
 
 echo "=== creating postgres database"
 postgres_done=0

--- a/config/onebusaway-enterprise-acta-webapp-data-sources.xml
+++ b/config/onebusaway-enterprise-acta-webapp-data-sources.xml
@@ -26,4 +26,12 @@
   </bean>
   <bean id="searchServiceImpl" class="org.onebusaway.presentation.impl.search.SearchServiceImpl" />
   <bean id="enterpriseGeocoderImpl" class="org.onebusaway.geocoder.enterprise.impl.EnterpriseGoogleGeocoderImpl" />
+  <bean id="wikiDocumentService" class="org.onebusaway.wiki.xwiki.impl.XWikiDocumentServiceImpl">
+    <property name="xwikiUrl" value="http://example.org/xwiki" />
+  </bean>
+  <bean id="wikiRenderingService" class="org.onebusaway.wiki.xwiki.impl.XWikiRenderingServiceImpl">
+    <property name="wikiDocumentViewUrl" value="view" />
+    <property name="wikiDocumentEditUrl" value="edit" />
+    <property name="wikiAttachmentUrl" value="attach" />
+  </bean>
 </beans>

--- a/config/onebusaway-enterprise-acta-webapp-data-sources.xml
+++ b/config/onebusaway-enterprise-acta-webapp-data-sources.xml
@@ -34,4 +34,20 @@
     <property name="wikiDocumentEditUrl" value="edit" />
     <property name="wikiAttachmentUrl" value="attach" />
   </bean>
+  <bean id="agencyMetadataSessionFactory" class="org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean">
+    <property name="dataSource" ref="agencyMetadataDataSource" />
+    <property name="annotatedClasses">
+      <list>
+        <value>org.onebusaway.agency_metadata.model.AgencyMetadata</value>
+        <value>org.onebusaway.agency_metadata.service.AgencyMetadataDaoImpl</value>
+      </list>
+    </property>
+    <property name="hibernateProperties">
+      <props>
+        <prop key="hibernate.connection.pool_size">1</prop>
+        <prop key="hibernate.current_session_context_class">thread</prop>
+        <prop key="hibernate.cache.provider_class">org.hibernate.cache.NoCacheProvider</prop>
+      </props>
+    </property>
+  </bean>
 </beans>


### PR DESCRIPTION
In https://github.com/docker-library/postgres/pull/658 a change was
made to the postgres image to require a password by default or
explicit disabling of auth.

For bin/ci, disable auth to keep configs simple. Add a note reminding
that doing this is highly insecure and should not be done in production.

Updates #19 