### PR TITLE
Revise environment variables used for database connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,9 @@ services:
       - oba_database
     build: ./oba
     environment:
-      - db.url=jdbc:mysql://oba_database:3306/oba_database
-      - db.user=oba_user
-      - db.password=oba_password
+      - JDBC_URL=jdbc:mysql://oba_database:3306/oba_database
+      - JDBC_USER=oba_user
+      - JDBC_PASSWORD=oba_password
     volumes:
       # Share the host's `bundle` directory
       # with the filesystem of the OBA service.

--- a/oba/config/onebusaway-api-webapp-data-sources.xml
+++ b/oba/config/onebusaway-api-webapp-data-sources.xml
@@ -20,16 +20,16 @@
   <!-- Database Configuration -->
   <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
     <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
-    <property name="url" value="${db.url}" />
-    <property name="username" value="${db.user}" />
-    <property name="password" value="${db.password}" />
+    <property name="url" value="${JDBC_URL}" />
+    <property name="username" value="${JDBC_USER}" />
+    <property name="password" value="${JDBC_PASSWORD}" />
   </bean>
 
   <bean id="agencyMetadataDataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
     <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
-    <property name="url" value="${db.url}" />
-    <property name="username" value="${db.user}" />
-    <property name="password" value="${db.password}" />
+    <property name="url" value="${JDBC_URL}" />
+    <property name="username" value="${JDBC_USER}" />
+    <property name="password" value="${JDBC_PASSWORD}" />
   </bean>
 
   <bean id="agencyMetadataSessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">

--- a/oba/config/onebusaway-enterprise-acta-webapp-data-sources.xml
+++ b/oba/config/onebusaway-enterprise-acta-webapp-data-sources.xml
@@ -27,9 +27,9 @@
   <!-- Database Configuration -->
   <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
     <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
-    <property name="url" value="${db.url}" />
-    <property name="username" value="${db.user}" />
-    <property name="password" value="${db.password}" />
+    <property name="url" value="${JDBC_URL}" />
+    <property name="username" value="${JDBC_USER}" />
+    <property name="password" value="${JDBC_PASSWORD}" />
   </bean>
 
   <alias name="dataSource" alias="mutableDataSource" />

--- a/oba/config/onebusaway-transit-data-federation-webapp-data-sources.xml
+++ b/oba/config/onebusaway-transit-data-federation-webapp-data-sources.xml
@@ -11,9 +11,9 @@
 
   <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
     <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
-    <property name="url" value="${db.url}" />
-    <property name="username" value="${db.user}" />
-    <property name="password" value="${db.password}" />
+    <property name="url" value="${JDBC_URL}" />
+    <property name="username" value="${JDBC_USER}" />
+    <property name="password" value="${JDBC_PASSWORD}" />
   </bean>
 
   <bean class="org.onebusaway.container.spring.SystemPropertyOverrideConfigurer">


### PR DESCRIPTION
Digital Ocean refuses to let you use environment variables with periods in them, so we're going back to ALL_CAPS.