### PR TITLE
feat: Add auto tag, build and push to GitHub CI

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,52 @@
+name: Docker
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        context: [ bundler, oba ]
+        include:
+          - name: onebusaway-bundle-builder
+            context: bundler
+          - name: onebusaway-api-webapp
+            context: oba
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.context }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push images
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          # for versioning, use the git sha
+          tags: |
+            altonhe/${{ matrix.name }}:latest
+            altonhe/${{ matrix.name }}:${{ github.sha }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -48,5 +48,5 @@ jobs:
           push: true
           # for versioning, use the git sha
           tags: |
-            altonhe/${{ matrix.name }}:latest
-            altonhe/${{ matrix.name }}:${{ github.sha }}
+            aaronbrethorst/${{ matrix.name }}:latest
+            aaronbrethorst/${{ matrix.name }}:${{ github.sha }}


### PR DESCRIPTION
As discussed in #43, this PR introduces automatic building, tagging, and pushing of Docker images into our existing CI process.

* It incorporates `linux/amd64`, `linux/arm64`, `linux/arm/v7` platforms to ensure compatibility ranging from `amd64` architectures to Apple Silicon.
* It ensures every version is tagged appropriately, with the latest tag always pointing to the most recent version.

I did some tests in my repo:
Actions:
* https://github.com/Altonhe/onebusaway-docker/actions/runs/8058511985
Results:
* https://hub.docker.com/repository/docker/altonhe/onebusaway-api-webapp
* https://hub.docker.com/repository/docker/altonhe/onebusaway-bundle-builder
