### PR TITLE
feat: Improve API key management

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,28 +31,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      # Add test API key to the OBA service
-      - name: Patch XML
-        uses: jannekem/run-python-script-action@v1
-        with:
-          script: |
-            import xml.etree.ElementTree as ET
-            f = './oba/config/onebusaway-api-webapp-data-sources.xml'
-            ET.register_namespace('', "http://www.springframework.org/schema/beans")
-            tree = ET.parse(f)
-            root = tree.getroot()
-            new_node = ET.Element('bean')
-            new_node.set('class', 'org.onebusaway.users.impl.CreateApiKeyAction')
-            property_node = ET.SubElement(new_node, 'property')
-            property_node.set('name', 'key')
-            property_node.set('value', 'TEST')
-            root.append(new_node)
-            tree.write(f)
-
       - name: Docker Compose up
         run: docker-compose up -d
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      # Add test API key to the OBA service
+      - name: Patch XML
+        uses: jannekem/run-python-script-action@v1
+        with:
+          script: |
+            import xml.etree.ElementTree as ET
+            f = './oba/config/onebusaway-api-webapp-data-sources.xml'
+            ET.register_namespace('', "http://www.springframework.org/schema/beans")
+            tree = ET.parse(f)
+            root = tree.getroot()
+            new_node = ET.Element('bean')
+            new_node.set('class', 'org.onebusaway.users.impl.CreateApiKeyAction')
+            property_node = ET.SubElement(new_node, 'property')
+            property_node.set('name', 'key')
+            property_node.set('value', 'TEST')
+            root.append(new_node)
+            tree.write(f)
+
       - name: Docker Compose up
         run: docker-compose up -d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,11 @@ services:
     container_name: oba_app
     depends_on:
       - oba_database
-    build: ./oba
+    build:
+      context: ./oba
+      # For test only, remove in production
+      args:
+        - TEST_API_KEY=TEST
     environment:
       - JDBC_URL=jdbc:mysql://oba_database:3306/oba_database
       - JDBC_USER=oba_user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       context: ./oba
       # For test only, remove in production
       args:
-        - TEST_API_KEY=TEST
+        - TEST_API_KEY=test
     environment:
       - JDBC_URL=jdbc:mysql://oba_database:3306/oba_database
       - JDBC_USER=oba_user

--- a/oba/Dockerfile
+++ b/oba/Dockerfile
@@ -46,6 +46,15 @@ RUN cp /oba/libs/onebusaway-api-webapp-${OBA_VERSION}.war .
 RUN jar xvf onebusaway-api-webapp-${OBA_VERSION}.war
 RUN rm onebusaway-api-webapp-${OBA_VERSION}.war
 COPY ./config/onebusaway-api-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
+# Append Test API Key dynamically
+ARG TEST_API_KEY
+ENV TEST_API_KEY=${TEST_API_KEY}
+COPY bootstrap.sh .
+USER root
+RUN chmod +x bootstrap.sh
+RUN apt-get update -y && apt-get install -y xmlstarlet && apt-get clean
+USER $USER
+RUN ./bootstrap.sh
 RUN cp $CATALINA_HOME/lib/mysql-connector-j-8.3.0.jar ./WEB-INF/lib
 RUN mv /oba/webapps/onebusaway-api-webapp $CATALINA_HOME/webapps
 

--- a/oba/Dockerfile
+++ b/oba/Dockerfile
@@ -1,3 +1,16 @@
+FROM alpine:latest as builder
+# Append Test API Key dynamically
+ARG TEST_API_KEY
+ENV TEST_API_KEY=${TEST_API_KEY}
+
+WORKDIR /oba
+COPY bootstrap.sh .
+COPY ./config ./config
+RUN chmod +x bootstrap.sh
+RUN apk update && apk add --no-cache bash && apk add --no-cache xmlstarlet
+RUN ./bootstrap.sh
+
+
 FROM tomcat:8.5.98-jdk11-temurin
 
 ENV CATALINA_HOME /usr/local/tomcat
@@ -45,16 +58,7 @@ WORKDIR /oba/webapps/onebusaway-api-webapp
 RUN cp /oba/libs/onebusaway-api-webapp-${OBA_VERSION}.war .
 RUN jar xvf onebusaway-api-webapp-${OBA_VERSION}.war
 RUN rm onebusaway-api-webapp-${OBA_VERSION}.war
-COPY ./config/onebusaway-api-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
-# Append Test API Key dynamically
-ARG TEST_API_KEY
-ENV TEST_API_KEY=${TEST_API_KEY}
-COPY bootstrap.sh .
-USER root
-RUN chmod +x bootstrap.sh
-RUN apt-get update -y && apt-get install -y xmlstarlet && apt-get clean
-RUN ./bootstrap.sh
-USER $USER
+COPY --from=builder /oba/config/onebusaway-api-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
 RUN cp $CATALINA_HOME/lib/mysql-connector-j-8.3.0.jar ./WEB-INF/lib
 RUN mv /oba/webapps/onebusaway-api-webapp $CATALINA_HOME/webapps
 

--- a/oba/Dockerfile
+++ b/oba/Dockerfile
@@ -53,8 +53,8 @@ COPY bootstrap.sh .
 USER root
 RUN chmod +x bootstrap.sh
 RUN apt-get update -y && apt-get install -y xmlstarlet && apt-get clean
-USER $USER
 RUN ./bootstrap.sh
+USER $USER
 RUN cp $CATALINA_HOME/lib/mysql-connector-j-8.3.0.jar ./WEB-INF/lib
 RUN mv /oba/webapps/onebusaway-api-webapp $CATALINA_HOME/webapps
 

--- a/oba/bootstrap.sh
+++ b/oba/bootstrap.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+XML_FILE="./WEB-INF/classes/data-sources.xml"
+NAMESPACE_PREFIX="x"
+NAMESPACE_URI="http://www.springframework.org/schema/beans"
+BEAN_ID="testAPIKey"
+
+# Check if the TEST_API_KEY environment variable is set
+if [ -n "$TEST_API_KEY" ]; then
+  # If it is set, then add the API key to the data-sources.xml file
+    echo "TEST_API_KEY set to $TEST_API_KEY, setting API key in data-sources.xml"
+    xmlstarlet ed -L -N ${NAMESPACE_PREFIX}=${NAMESPACE_URI} \
+        -s "//${NAMESPACE_PREFIX}:bean[@id='${BEAN_ID}']" -t elem -n "property" -v "" \
+        -i "//${NAMESPACE_PREFIX}:bean[@id='${BEAN_ID}']/property[not(@name)]" -t attr -n "name" -v "key" \
+        -i "//${NAMESPACE_PREFIX}:bean[@id='${BEAN_ID}']/property[@name='key']" -t attr -n "value" -v "${TEST_API_KEY}" \
+        ${XML_FILE}
+else
+  # If it is not set, then remove the element from the data-sources.xml file
+    echo "TEST_API_KEY environment variable is not set. Removing element from data-sources.xml"
+    xmlstarlet ed -L -N ${NAMESPACE_PREFIX}=${NAMESPACE_URI} \
+        -d "//${NAMESPACE_PREFIX}:bean[@id='${BEAN_ID}']" \
+        ${XML_FILE}
+fi

--- a/oba/bootstrap.sh
+++ b/oba/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-XML_FILE="./WEB-INF/classes/data-sources.xml"
+XML_FILE="./config/onebusaway-api-webapp-data-sources.xml"
 NAMESPACE_PREFIX="x"
 NAMESPACE_URI="http://www.springframework.org/schema/beans"
 BEAN_ID="testAPIKey"

--- a/oba/config/onebusaway-api-webapp-data-sources.xml
+++ b/oba/config/onebusaway-api-webapp-data-sources.xml
@@ -56,11 +56,6 @@
     <constructor-arg type="java.lang.String" value="" />
   </bean>
 
-  <!-- Allows the TEST key for OBA API testing.  Should be removed in production -->
-  <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
-    <property name="key" value="TEST"/>
-  </bean>
-
   <!-- iOS Client key -->
   <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
     <property name="key" value="org.onebusaway.iphone"/>

--- a/oba/config/onebusaway-api-webapp-data-sources.xml
+++ b/oba/config/onebusaway-api-webapp-data-sources.xml
@@ -66,6 +66,10 @@
     <property name="key" value="v1_BktoDJ2gJlu6nLM6LsT9H8IUbWc=cGF1bGN3YXR0c0BnbWFpbC5jb20="/>
   </bean>
 
+  <!-- Allows the TEST key for OBA API testing.  Automated handled in `bootstrap.sh` -->
+  <bean id="testAPIKey" class="org.onebusaway.users.impl.CreateApiKeyAction">
+  </bean>
+
   <bean class="org.onebusaway.container.spring.PropertyOverrideConfigurer">
     <property name="properties">
       <props>


### PR DESCRIPTION
In response to issue #10, I've modified our approach to API key management to ensure that test keys are only used during the CI test process. This change prevents test keys from being mistakenly used in production. I've configured the test API key to work with the `validate.sh` script, to test the service's endpoints during the CI process.