### PR TITLE
feat: build and push tagged image upon a new release

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,9 +3,12 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [ published ]
 
 jobs:
   buildx:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,3 +53,47 @@ jobs:
           tags: |
             opentransitsoftwarefoundation/${{ matrix.name }}:latest
             opentransitsoftwarefoundation/${{ matrix.name }}:${{ github.sha }}
+
+  buildx-release:
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        context: [ bundler, oba ]
+        include:
+          - name: onebusaway-bundle-builder
+            context: bundler
+          - name: onebusaway-api-webapp
+            context: oba
+    steps:
+      - name: Compute image tag name
+        run: echo "IMAGE_TAG=$(echo $GITHUB_REF_NAME)" >> $GITHUB_ENV
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push images
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            opentransitsoftwarefoundation/${{ matrix.name }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
In response to #60, this PR will automatically build, tag, and push docker images while publishing a new release. The docker image tag is the same as the release tag.
Here is a demo in my own repo, I create a release by using tag `2.4.18-cs-v1.0.0` in 
https://github.com/Altonhe/onebusaway-docker/releases/tag/2.4.18-cs-v1.0.0, 
and the action is triggered here: 
https://github.com/Altonhe/onebusaway-docker/actions/runs/8285296607 (failed due to no credentials)
```
ERROR: failed to solve: failed to push opentransitsoftwarefoundation/onebusaway-bundle-builder:2.4.18-cs-v1.0.0: push access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
Error: buildx failed with: ERROR: failed to solve: failed to push opentransitsoftwarefoundation/onebusaway-bundle-builder:2.4.18-cs-v1.0.0: push access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```