### PR TITLE
feat: allow adjusting configurations through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You will then have three webapps available:
 
 - API, hosted at `http://localhost:8080/onebusaway-api-webapp/api?key=TEST`
   - an example call could be to `http://localhost:8080/onebusaway-api-webapp/api/where/agencies-with-coverage.json?key=TEST`, which should show metadata about the agency you loaded
-  - the test/demo API key is automatically handled in `oba/bootstrap.sh`, you can change it by setting the `TEST_API_KEY` build args in the `oba_app` service in `docker-compose.yml`
+  - the test/demo API key is automatically handled in `oba/bootstrap.sh`, you can change it by setting the `TEST_API_KEY` environment variables in the `oba_app` service in `docker-compose.yml`
 
 When done using this web server, you can use the shell-standard `^C` to exit out and turn it off. If issues persist across runs, you can try using `docker-compose down -v` and then `docker-compose up oba_app` to refresh the Docker containers and services.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ You can find the latest published Docker images on Docker Hub:
     * `FEED_API_KEY` - If your GTFS-RT API requires you to pass an authentication header, you can represent the key portion of it by specifying this value.
     * `FEED_API_VALUE` - If your GTFS-RT API requires you to pass an authentication header, you can represent the value portion of it by specifying this value.
 
+The `GTFS-RT` and `Google Map` related variables will be handled by the `oba/bootstrap.sh` script, which will set the config files for the OBA API webapp. If you want to use your own config files, you could set `USER_CONFIGURED=1` in the `oba_app` service in `docker-compose.yml` to skip `bootstrap.sh` and write your config file in the container.
+```yaml
+  oba_app:
+    container_name: oba_app
+    depends_on:
+      - oba_database
+    build:
+      context: ./oba
+    environment:
+      # database configs are read from environment variables
+      - JDBC_URL=jdbc:mysql://oba_database:3306/oba_database
+      - JDBC_USER=oba_user
+      - JDBC_PASSWORD=oba_password
+      # skip bootstrap.sh and use user-configured config files
+      - USER_CONFIGURED=1
+```
+
 You will also need to create a transit data bundle from a GTFS Zip file. This needs more documentation, but this README does a decent job of outlining the process. The only tricky part is that you need to get it into your running container. Currently, we recommend building it locally, uploading the contents of the `./bundle` directory to S3 or another publicly accessible website, and then downloading it into your container. Obviously, this needs some improvement.
 
 ### Deploy to Render

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,13 +30,11 @@ services:
       - oba_database
     build:
       context: ./oba
-      # For test only, remove in production
-      args:
-        - TEST_API_KEY=test
     environment:
       - JDBC_URL=jdbc:mysql://oba_database:3306/oba_database
       - JDBC_USER=oba_user
       - JDBC_PASSWORD=oba_password
+      - TEST_API_KEY=test # For test only, remove in production
     volumes:
       # Share the host's `bundle` directory
       # with the filesystem of the OBA service.

--- a/oba/Dockerfile
+++ b/oba/Dockerfile
@@ -1,48 +1,3 @@
-FROM alpine:latest as builder
-# Append Test API Key dynamically
-ARG TEST_API_KEY
-ENV TEST_API_KEY=${TEST_API_KEY}
-
-# GTFS Realtime URLs
-ARG TRIP_UPDATES_URL
-ENV TRIP_UPDATES_URL=${TRIP_UPDATES_URL}
-
-ARG VEHICLE_POSITIONS_URL
-ENV VEHICLE_POSITIONS_URL=${VEHICLE_POSITIONS_URL}
-
-ARG ALERTS_URL
-ENV ALERTS_URL=${ALERTS_URL}
-
-ARG REFRESH_INTERVAL
-ENV REFRESH_INTERVAL=${REFRESH_INTERVAL}
-
-ARG AGENCY_ID
-ENV AGENCY_ID=${AGENCY_ID}
-
-ARG FEED_API_KEY
-ENV FEED_API_KEY=${FEED_API_KEY}
-
-ARG FEED_API_VALUE
-ENV FEED_API_VALUE=${FEED_API_VALUE}
-
-# Google Maps related variables
-ARG GOOGLE_MAPS_API_KEY
-ENV GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY}
-
-ARG GOOGLE_MAPS_CHANNEL_ID
-ENV GOOGLE_MAPS_CHANNEL_ID=${GOOGLE_MAPS_CHANNEL_ID}
-
-ARG GOOGLE_MAPS_CLIENT_ID
-ENV GOOGLE_MAPS_CLIENT_ID=${GOOGLE_MAPS_CLIENT_ID}
-
-WORKDIR /oba
-COPY bootstrap.sh .
-COPY ./config ./config
-RUN chmod +x bootstrap.sh
-RUN apk update && apk add --no-cache bash jq && apk add --no-cache xmlstarlet
-RUN ./bootstrap.sh
-
-
 FROM tomcat:8.5.98-jdk11-temurin
 
 ENV CATALINA_HOME /usr/local/tomcat
@@ -58,8 +13,6 @@ RUN groupadd -g $GID $GROUP && \
     chown -R $USER:$GROUP $CATALINA_HOME && \
     mkdir -p /var/log/tomcat8 && \
     chown -R $USER:$GROUP /var/log/tomcat8
-
-USER $USER
 
 # MySQL Connector
 WORKDIR $CATALINA_HOME/lib
@@ -82,7 +35,7 @@ WORKDIR /oba/webapps/onebusaway-transit-data-federation-webapp
 RUN cp /oba/libs/onebusaway-transit-data-federation-webapp-${OBA_VERSION}.war .
 RUN jar xvf onebusaway-transit-data-federation-webapp-${OBA_VERSION}.war
 RUN rm onebusaway-transit-data-federation-webapp-${OBA_VERSION}.war
-COPY --from=builder /oba/config/onebusaway-transit-data-federation-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
+COPY ./config/onebusaway-transit-data-federation-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
 RUN cp $CATALINA_HOME/lib/mysql-connector-j-8.3.0.jar ./WEB-INF/lib
 RUN mv /oba/webapps/onebusaway-transit-data-federation-webapp $CATALINA_HOME/webapps
 
@@ -90,7 +43,7 @@ WORKDIR /oba/webapps/onebusaway-api-webapp
 RUN cp /oba/libs/onebusaway-api-webapp-${OBA_VERSION}.war .
 RUN jar xvf onebusaway-api-webapp-${OBA_VERSION}.war
 RUN rm onebusaway-api-webapp-${OBA_VERSION}.war
-COPY --from=builder /oba/config/onebusaway-api-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
+COPY ./config/onebusaway-api-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
 RUN cp $CATALINA_HOME/lib/mysql-connector-j-8.3.0.jar ./WEB-INF/lib
 RUN mv /oba/webapps/onebusaway-api-webapp $CATALINA_HOME/webapps
 
@@ -98,7 +51,13 @@ WORKDIR /oba/webapps/onebusaway-enterprise-acta-webapp
 RUN cp /oba/libs/onebusaway-enterprise-acta-webapp-${OBA_VERSION}.war .
 RUN jar xvf onebusaway-enterprise-acta-webapp-${OBA_VERSION}.war
 RUN rm onebusaway-enterprise-acta-webapp-${OBA_VERSION}.war
-COPY --from=builder /oba/config/onebusaway-enterprise-acta-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
+COPY ./config/onebusaway-enterprise-acta-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
 RUN cp $CATALINA_HOME/lib/mysql-connector-j-8.3.0.jar ./WEB-INF/lib
 RUN mv /oba/webapps/onebusaway-enterprise-acta-webapp $CATALINA_HOME/webapps
-COPY --from=builder /oba/tmp/ /var/lib/oba/
+
+RUN apt-get update && apt-get install -y xmlstarlet jq supervisor&& apt-get clean
+COPY bootstrap.sh /oba/bootstrap.sh
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+RUN chmod +x /oba/bootstrap.sh
+
+CMD ["supervisord", "-n"]

--- a/oba/bootstrap.sh
+++ b/oba/bootstrap.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-WEBAPP_API_XML_FILE="./config/onebusaway-api-webapp-data-sources.xml"
+WEBAPP_API_XML_FILE="$CATALINA_HOME/webapps/onebusaway-api-webapp/WEB-INF/classes/data-sources.xml"
 NAMESPACE_PREFIX="x"
 NAMESPACE_URI="http://www.springframework.org/schema/beans"
 BEAN_ID="testAPIKey"
+
+# For users who want to configure the data-sources.xml file themselves
+if [ -n "$USER_CONFIGURED" ]; then
+    echo "USER_CONFIGURED is set, you should create your own configuration file, Aborting..."
+    exit 0
+fi
 
 # Check if the TEST_API_KEY environment variable is set
 if [ -n "$TEST_API_KEY" ]; then
@@ -22,7 +28,7 @@ else
         ${WEBAPP_API_XML_FILE}
 fi
 
-DATA_FEDERATION_XML_FILE="./config/onebusaway-transit-data-federation-webapp-data-sources.xml"
+DATA_FEDERATION_XML_FILE="$CATALINA_HOME/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/classes/data-sources.xml"
 BEAN_ID="gtfsRT"
 # Check if GTFS-Rt related environment variables are set
 if [ -z "$TRIP_UPDATES_URL" ] && [ -z "$VEHICLE_POSITIONS_URL" ] && [ -z "$ALERTS_URL" ]; then
@@ -88,9 +94,9 @@ else
 fi
 
 # Google map related environment variables
-ENTERPRISE_ACTA_WEBAPP_XML_FILE="./config/onebusaway-enterprise-acta-webapp-data-sources.xml"
+ENTERPRISE_ACTA_WEBAPP_XML_FILE="$CATALINA_HOME/webapps/onebusaway-enterprise-acta-webapp/WEB-INF/classes/data-sources.xml"
 BEAN_ID="configurationServiceClient"
-LOCAL_JSON_FILE="/oba/tmp/config.json"
+LOCAL_JSON_FILE="/var/lib/oba/config.json"
 mkdir -p $(dirname "$LOCAL_JSON_FILE")
 if [ -z "$GOOGLE_MAPS_API_KEY" ] && [ -z "$GOOGLE_MAPS_CLIENT_ID" ] && [ -z "$GOOGLE_MAPS_CHANNEL_ID" ]; then
     echo "No Google Maps related environment variables are set. Removing element from data-sources.xml"
@@ -108,7 +114,7 @@ else
         ${ENTERPRISE_ACTA_WEBAPP_XML_FILE}
 
     # Avoid read and write same file in one pipe to avoid race condition
-    TMP_JSON_FILE="./config/tmp.json"
+    TMP_JSON_FILE="./tmp.json"
     touch "$TMP_JSON_FILE"
     if [ -n "$GOOGLE_MAPS_API_KEY" ]; then
         cat "$LOCAL_JSON_FILE" | jq '.config += [{"component": "display", "key": "display.googleMapsApiKey", "value": "'"$GOOGLE_MAPS_API_KEY"'"}]' > "$TMP_JSON_FILE"

--- a/oba/supervisord.conf
+++ b/oba/supervisord.conf
@@ -1,0 +1,21 @@
+[program:start]
+command=/oba/bootstrap.sh
+autostart=true
+autorestart=false
+startsecs=0
+startretries=0
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+
+[program:tomcat]
+user=oba_user
+command=catalina.sh run
+autostart=true
+autorestart=true
+depends_on=start
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0


### PR DESCRIPTION
Before, I used a two-step build process to prevent unnecessary libraries from being included in the final runtime image. However, this approach meant that configuration changes could only be made during the build phase, requiring a rebuild for any modifications. To improve flexibility, I suggest allowing users to update the configuration through environment variables, instead of needing to rebuild everything locally.

In this pull request, I've incorporated [Supervisor](http://supervisord.org/) to oversee both the bootstrap.sh script and the tomcat server. Here's how it works:

1. If we set the Docker command to `CMD ['bootstrap.sh']`, Docker executes the script as its first process (PID 1). When the script completes, the container stops running.
2. We want the `tomcat` server to start only after `bootstrap.sh` has finished executing.
As mentioned in issue #34, it's better for security reasons to run the container as a non-root user.
3. Supervisor solves these problems by ensuring a sequential execution: it starts the `tomcat` server only after `bootstrap.sh` has completed, and it runs the server under a non-root user account(`oba_user`).

```
# ps -ef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 19:19 ?        00:00:00 /usr/bin/python3 /usr/bin/supervisord -n
oba_user     8     1 24 19:19 ?        00:03:20 /opt/java/openjdk/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Djdk.tls.ephemeralDHKe
root       177     0  0 19:21 pts/0    00:00:00 /bin/sh
root       270   177  0 19:33 pts/0    00:00:00 ps -ef
```

now, you can start the server by environment variables, instead of build args:
```
  oba_app:
    container_name: oba_app
    depends_on:
      - oba_database
    build:
      context: ./oba
    environment:
      - JDBC_URL=jdbc:mysql://oba_database:3306/oba_database
      - JDBC_USER=oba_user
      - JDBC_PASSWORD=oba_password
      - TEST_API_KEY=test # For test only, remove in production
      - VEHICLE_POSITIONS_URL=https://opendata.burlington.ca/gtfs-rt/GTFS_VehiclePositions.pb
      - TRIP_UPDATES_URL=https://opendata.burlington.ca/gtfs-rt/GTFS_TripUpdates.pb
      - ALERTS_URL=https://opendata.burlington.ca/gtfs-rt/GTFS_ServiceAlerts.pb
      - REFRESH_INTERVAL=30
      - AGENCY_ID=Burlington
      - GOOGLE_MAPS_API_KEY=<YOUR_KEY_HERE>
      - GOOGLE_MAPS_CLIENT_ID=<YOUR_CHANNEL_ID_HERE>
      - GOOGLE_MAPS_CHANNEL_ID=<YOUR_CLIENT_ID_HERE>
    volumes:
      # Share the host's `bundle` directory
      # with the filesystem of the OBA service.
      - ./bundle:/bundle
    ports:
      # Access the webapp on your host machine at a path like
      # http://localhost:8080/onebusaway-api-webapp/api/where/agency/${YOUR_AGENCY}.json?key=TEST
      - "8080:8080"
    # restart: always
```
    
For users who want to configure their data-source file manually, just set environment `USER_CONFIGURED=1`