### PR TITLE
feat: allow build bundle inside `oba_app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ You can find the latest published Docker images on Docker Hub:
   * `JDBC_URL` - The JDBC connection URL for your MySQL database.
   * `JDBC_USER` - The username for your MySQL database.
   * `JDBC_PASSWORD` - The password for your MySQL database.
+* GTFS (Optional, required only when using `oba_app` independently)
+  * `GTFS_URL` - The URL to the GTFS feed you want to use.
 * GTFS-RT Support (Optional)
   * `ALERTS_URL` - Service Alerts URL for GTFS-RT.
   * `TRIP_UPDATES_URL` - Trip Updates URL for GTFS-RT.
@@ -91,6 +93,8 @@ The `GTFS-RT` and `Google Map` related variables will be handled by the `oba/boo
       - JDBC_URL=jdbc:mysql://oba_database:3306/oba_database
       - JDBC_USER=oba_user
       - JDBC_PASSWORD=oba_password
+      # change this to your GTFS url
+      - GTFS_URL=https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip
       # skip bootstrap.sh and use user-configured config files
       - USER_CONFIGURED=1
 ```

--- a/oba/Dockerfile
+++ b/oba/Dockerfile
@@ -2,6 +2,7 @@ FROM tomcat:8.5.98-jdk11-temurin
 
 ENV CATALINA_HOME /usr/local/tomcat
 ARG OBA_VERSION=2.4.18-cs
+ENV OBA_VERSION=$OBA_VERSION
 
 ARG GID=1000
 ARG UID=1000
@@ -38,6 +39,9 @@ WORKDIR /oba/libs
 RUN wget "https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-api-webapp/${OBA_VERSION}/onebusaway-api-webapp-${OBA_VERSION}.war"
 RUN wget "https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-enterprise-acta-webapp/${OBA_VERSION}/onebusaway-enterprise-acta-webapp-${OBA_VERSION}.war"
 RUN wget "https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-transit-data-federation-webapp/${OBA_VERSION}/onebusaway-transit-data-federation-webapp-${OBA_VERSION}.war"
+
+# Bundle builder
+WORKDIR /oba/tools
 RUN wget "https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-transit-data-federation-builder/${OBA_VERSION}/onebusaway-transit-data-federation-builder-${OBA_VERSION}-withAllDependencies.jar"
 
 # Tomcat Configuration

--- a/oba/bootstrap.sh
+++ b/oba/bootstrap.sh
@@ -5,6 +5,21 @@ NAMESPACE_PREFIX="x"
 NAMESPACE_URI="http://www.springframework.org/schema/beans"
 BEAN_ID="testAPIKey"
 
+# Build bundle inside the container
+if [ -n "$GTFS_URL" ]; then
+    echo "GTFS_URL is set, building bundle..."
+    echo "OBA Bundle Builder Starting"
+    echo "GTFS_URL: $GTFS_URL"
+    echo "OBA Version: $OBA_VERSION"
+    mkdir -p /bundle
+    wget -O /bundle/gtfs.zip "$GTFS_URL"
+    cd /bundle \
+        && java -Xss4m -Xmx3g \
+            -jar /oba/tools/onebusaway-transit-data-federation-builder-${OBA_VERSION}-withAllDependencies.jar \
+            ./gtfs.zip \
+            .
+fi
+
 # For users who want to configure the data-sources.xml file themselves
 if [ -n "$USER_CONFIGURED" ]; then
     echo "USER_CONFIGURED is set, you should create your own configuration file, Aborting..."
@@ -29,6 +44,7 @@ else
 fi
 
 DATA_FEDERATION_XML_FILE="$CATALINA_HOME/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/classes/data-sources.xml"
+DATA_SOURCE_CLASS="org.onebusaway.transit_data_federation.impl.realtime.gtfs_realtime.GtfsRealtimeSource"
 BEAN_ID="gtfsRT"
 # Check if GTFS-Rt related environment variables are set
 if [ -z "$TRIP_UPDATES_URL" ] && [ -z "$VEHICLE_POSITIONS_URL" ] && [ -z "$ALERTS_URL" ]; then


### PR DESCRIPTION
Allow to build bundle inside `oba_app`, you can try with:
```yaml
  oba_app:
    container_name: oba_app
    depends_on:
      - oba_database
    build:
      context: ./oba
    environment:
      - JDBC_URL=jdbc:mysql://oba_database:3306/oba_database
      - JDBC_USER=oba_user
      - JDBC_PASSWORD=oba_password
      - TEST_API_KEY=test # For test only, remove in production
      - GTFS_URL=https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip
      - 
    ports:
      # Access the webapp on your host machine at a path like
      # http://localhost:8080/onebusaway-api-webapp/api/where/agency/${YOUR_AGENCY}.json?key=TEST
      - "8080:8080"
    # restart: always
```
    
Result:
![image](https://github.com/OneBusAway/onebusaway-docker/assets/28844720/df16e05a-d57c-47b7-89c1-014fd9571ce4)
```zsh
(base) ➜  bin git:(feature/bundle-builder) ✗ ./validate.sh
current-time.json endpoint works.
agencies-with-coverage.json endpoint works.
routes-for-agency/unitrans.json endpoint works.
stops-for-route/unitrans_C.json endpoint works.
stop/unitrans_22182.json endpoint works.
```
