### PR TITLE
Allow configuration of the oba_app timezone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       - JDBC_USER=oba_user
       - JDBC_PASSWORD=oba_password
       - TEST_API_KEY=test # For test only, remove in production
+      - TZ=America/New_York
+
     volumes:
       # Share the host's `bundle` directory
       # with the filesystem of the OBA service.

--- a/oba/Dockerfile
+++ b/oba/Dockerfile
@@ -1,6 +1,7 @@
 FROM tomcat:8.5.98-jdk11-temurin
 
 ENV CATALINA_HOME /usr/local/tomcat
+ENV TZ=America/New_York
 ARG OBA_VERSION=2.4.18-cs
 ENV OBA_VERSION=$OBA_VERSION
 
@@ -13,10 +14,14 @@ RUN apt-get update && apt-get install -y \
     jq \
     magic-wormhole \
     supervisor \
+    tzdata \
     unzip \
     xmlstarlet \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Set the configured time zone
+RUN ln -fs /usr/share/zoneinfo/$TZ /etc/localtime && dpkg-reconfigure -f noninteractive tzdata
 
 RUN groupadd -g $GID $GROUP && \
     useradd -d /home/$USER -u $UID -m -s /bin/bash -g $GROUP $USER && \

--- a/render.yaml
+++ b/render.yaml
@@ -10,6 +10,8 @@ services:
     healthCheckPath: /onebusaway-api-webapp/api/where/current-time.json?key=org.onebusaway.iphone
     autoDeploy: false
     envVars:
+      - key: TZ
+        sync: false
       - key: GTFS_URL
         sync: false
       - key: VEHICLE_POSITIONS_URL


### PR DESCRIPTION
I suspect this is why I've been having trouble getting GTFS-RT working correctly. This commit modifies the oba_app Dockerfile to add support for setting the system timezone as an environment variable. It also specifies it as a configurable environment variable in the render.yaml file.