### PR TITLE
feat: ensuring the script is idempotent

### DIFF
--- a/oba/Dockerfile
+++ b/oba/Dockerfile
@@ -54,7 +54,7 @@ WORKDIR /oba/webapps/onebusaway-transit-data-federation-webapp
 RUN cp /oba/libs/onebusaway-transit-data-federation-webapp-${OBA_VERSION}.war .
 RUN jar xvf onebusaway-transit-data-federation-webapp-${OBA_VERSION}.war
 RUN rm onebusaway-transit-data-federation-webapp-${OBA_VERSION}.war
-COPY ./config/onebusaway-transit-data-federation-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
+COPY ./config/onebusaway-transit-data-federation-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml.bak
 RUN cp $CATALINA_HOME/lib/mysql-connector-j-8.3.0.jar ./WEB-INF/lib
 RUN mv /oba/webapps/onebusaway-transit-data-federation-webapp $CATALINA_HOME/webapps
 
@@ -62,7 +62,7 @@ WORKDIR /oba/webapps/onebusaway-api-webapp
 RUN cp /oba/libs/onebusaway-api-webapp-${OBA_VERSION}.war .
 RUN jar xvf onebusaway-api-webapp-${OBA_VERSION}.war
 RUN rm onebusaway-api-webapp-${OBA_VERSION}.war
-COPY ./config/onebusaway-api-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
+COPY ./config/onebusaway-api-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml.bak
 RUN cp $CATALINA_HOME/lib/mysql-connector-j-8.3.0.jar ./WEB-INF/lib
 RUN mv /oba/webapps/onebusaway-api-webapp $CATALINA_HOME/webapps
 
@@ -70,7 +70,7 @@ WORKDIR /oba/webapps/onebusaway-enterprise-acta-webapp
 RUN cp /oba/libs/onebusaway-enterprise-acta-webapp-${OBA_VERSION}.war .
 RUN jar xvf onebusaway-enterprise-acta-webapp-${OBA_VERSION}.war
 RUN rm onebusaway-enterprise-acta-webapp-${OBA_VERSION}.war
-COPY ./config/onebusaway-enterprise-acta-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml
+COPY ./config/onebusaway-enterprise-acta-webapp-data-sources.xml ./WEB-INF/classes/data-sources.xml.bak
 RUN cp $CATALINA_HOME/lib/mysql-connector-j-8.3.0.jar ./WEB-INF/lib
 RUN mv /oba/webapps/onebusaway-enterprise-acta-webapp $CATALINA_HOME/webapps
 


### PR DESCRIPTION
The previous script does not ensure idempotent, for example, when you restart the container, it will check if `TRIP_UPDATES_URL` has been set, and insert the value into the `data-source.xml`, this will cause duplicate values, like this:
```
  <bean id="gtfsRT" class="org.onebusaway.transit_data_federation.impl.realtime.gtfs_realtime.GtfsRealtimeSource">
    <property name="tripUpdatesUrl" value="https://opendata.burlington.ca/gtfs-rt/GTFS_TripUpdates.pb"/>
    <property name="vehiclePositionsUrl" value="https://opendata.burlington.ca/gtfs-rt/GTFS_VehiclePositions.pb"/>
    <property name="alertsUrl" value="https://opendata.burlington.ca/gtfs-rt/GTFS_ServiceAlerts.pb"/>
    <property name="refreshInterval" value="30"/>
    <property name="agencyId" value="Burlington"/>
     <property name="tripUpdatesUrl" value="https://opendata.burlington.ca/gtfs-rt/GTFS_TripUpdates.pb"/>
    <property name="vehiclePositionsUrl" value="https://opendata.burlington.ca/gtfs-rt/GTFS_VehiclePositions.pb"/>
    <property name="alertsUrl" value="https://opendata.burlington.ca/gtfs-rt/GTFS_ServiceAlerts.pb"/>
    <property name="refreshInterval" value="30"/>
    <property name="agencyId" value="Burlington"/>
     <property name="tripUpdatesUrl" value="https://opendata.burlington.ca/gtfs-rt/GTFS_TripUpdates.pb"/>
    <property name="vehiclePositionsUrl" value="https://opendata.burlington.ca/gtfs-rt/GTFS_VehiclePositions.pb"/>
    <property name="alertsUrl" value="https://opendata.burlington.ca/gtfs-rt/GTFS_ServiceAlerts.pb"/>
    <property name="refreshInterval" value="30"/>
    <property name="agencyId" value="Burlington"/>
  </bean>
```
this PR will ensure each config file will be the same no matter how many times the script is executed.