### PR TITLE
feat: add `docker-compose.prod.yml` for deployment

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,60 @@
+version: "3"
+
+services:
+  oba_bundler:
+    build: ./bundler
+    volumes:
+      - ./bundle:/bundle
+    environment:
+      - GTFS_URL
+
+  oba_database:
+    image: mysql:8.3
+    container_name: oba_database
+    environment:
+      MYSQL_ROOT_PASSWORD: Ins3cure!
+      MYSQL_DATABASE: oba_database
+      MYSQL_USER: oba_user
+      MYSQL_PASSWORD: oba_password
+    ports:
+      - "3306:3306"
+    volumes:
+      - type: volume
+        source: mysql-data
+        target: /var/lib/mysql
+    restart: always
+
+  oba_app:
+    image: opentransitsoftwarefoundation/onebusaway-api-webapp:${OBA_VERSION:-latest}
+    container_name: oba_app
+    depends_on:
+      - oba_database
+    environment:
+      - JDBC_URL=jdbc:mysql://oba_database:3306/oba_database
+      - JDBC_USER=oba_user
+      - JDBC_PASSWORD=oba_password
+      - TEST_API_KEY
+      - TZ
+      - VEHICLE_POSITIONS_URL
+      - TRIP_UPDATES_URL
+      - ALERTS_URL
+      - REFRESH_INTERVAL=30
+      - AGENCY_ID
+      - GOOGLE_MAPS_API_KEY
+
+    volumes:
+      # Share the host"s `bundle` directory
+      # with the filesystem of the OBA service.
+      - ./bundle:/bundle
+    ports:
+      # Access the webapp on your host machine at a path like
+      # http://localhost:8080/onebusaway-api-webapp/api/where/agency/${YOUR_AGENCY}.json?key=TEST
+      - "8080:8080"
+    # restart: always
+    labels:
+      caddy: "${DOMAIN}"
+      caddy.reverse_proxy: "{{upstreams 8080}}"
+
+volumes:
+  mysql-data:
+  caddy-data: {}


### PR DESCRIPTION
This Docker Compose file is designed to deploy the OBA server with Opentofu.

* The file includes all the necessary environment variables, making it easier to inject them using a `.env` file. For more details, see the [Docker documentation on setting environment variables](https://docs.docker.com/compose/environment-variables/set-environment-variables/#use-the-environment-attribute).

* It uses the prebuilt `opentransitsoftwarefoundation/onebusaway-api-webapp:latest` image, which saves build time, you can specify the version by setting the `OBA_VERSION` environment variable.

* The labels on `oba_app` are configured to work with `lucaslorentz/caddy-docker-proxy:ci-alpine`, enabling automatic HTTPS setup. The image is not included here to avoid coupling, allowing users the flexibility to configure their own certificates.