### PR TITLE
feat: upload docker image to `ghcr`

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -38,11 +38,6 @@ jobs:
           echo "Status:    ${{ steps.buildx.outputs.status }}"
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -56,8 +51,6 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
-            opentransitsoftwarefoundation/${{ matrix.name }}:latest
-            opentransitsoftwarefoundation/${{ matrix.name }}:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:latest
             ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ github.sha }}
 
@@ -96,12 +89,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push images
         uses: docker/build-push-action@v5
         with:
@@ -110,4 +97,3 @@ jobs:
           push: true
           tags: |
             opentransitsoftwarefoundation/${{ matrix.name }}:${{ env.IMAGE_TAG }}
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -43,16 +43,23 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push images
         uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.context }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          # for versioning, use the git sha
           tags: |
             opentransitsoftwarefoundation/${{ matrix.name }}:latest
             opentransitsoftwarefoundation/${{ matrix.name }}:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ github.sha }}
 
   buildx-release:
     if: ${{ github.event_name == 'release' }}
@@ -89,6 +96,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push images
         uses: docker/build-push-action@v5
         with:
@@ -97,3 +110,4 @@ jobs:
           push: true
           tags: |
             opentransitsoftwarefoundation/${{ matrix.name }}:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -50,6 +50,7 @@ jobs:
           context: ${{ matrix.context }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
+          # for versioning, use the git sha
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:latest
             ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ github.sha }}


### PR DESCRIPTION
docker hub has a rate limit on its free account, which will cause error code 409 when using ACI, GitHub public container registry currently doesn't have a rate limit, I have successfully deployed it by using an image from GHCR.
FYI: https://medium.com/@alaa.barqawi/docker-rate-limit-with-azure-container-instance-and-aks-4449cede66dd