### PR TITLE
feat: add `stops-for-location` endpoint test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker Compose up
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Wait for services to be up
         run: sleep 30
@@ -44,7 +44,7 @@ jobs:
 
       - name: Docker Compose down
         if: always()
-        run: docker-compose down
+        run: docker compose down
 
   services_standalone:
     name: Services standalone
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker Compose up
-        run: docker-compose -f docker-compose.standalone.yml up -d
+        run: docker compose -f docker-compose.standalone.yml up -d
 
       - name: Wait for services to be up
         # leave time to download and process the GTFS data
@@ -67,4 +67,4 @@ jobs:
 
       - name: Docker Compose down
         if: always()
-        run: docker-compose down
+        run: docker compose down

--- a/bin/validate.sh
+++ b/bin/validate.sh
@@ -42,6 +42,14 @@ else
     exit 1
 fi
 
+output=$(curl -s "http://localhost:8080/onebusaway-api-webapp/api/where/stops-for-location.json?lat=38.555308&lon=-121.735991&key=test" | jq '.data.outOfRange')
+if [[ ! -z "$output" && "$output" == "false" ]]; then
+    echo "stops-for-location/unitrans_false.json endpoint works."
+else
+    echo "Error: stops-for-location/unitrans_false.json endpoint is not working: $output"
+    exit 1
+fi
+
 # todo: add support for arrivals-and-departures-for-stop endpoint.
 # however, it doesn't seem that the unitrans_22182 stop has arrivals and departures on the weekend, so we'll need
 # something else to test with. However, for now, this is still a great step forward.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - JDBC_USER=oba_user
       - JDBC_PASSWORD=oba_password
       - TEST_API_KEY=test # For test only, remove in production
-      - TZ=America/New_York
+      - TZ=America/Los_Angeles
 
     volumes:
       # Share the host's `bundle` directory


### PR DESCRIPTION
update test workflow to migrations to v2, FYI: https://github.com/orgs/community/discussions/116610