### PR TITLE
Fix GTFS_URL environment variable being ignored by docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ./bundle:/bundle
     environment:
-      - GTFS_URL=https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip
+      - GTFS_URL=${GTFS_URL:-https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip}
 
   oba_database:
     image: mysql:8.4
@@ -54,7 +54,7 @@ services:
       - JDBC_PASSWORD=oba_password
       - TEST_API_KEY=test # For test only, remove in production
       - TZ=America/Los_Angeles
-      - GTFS_URL=https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip
+      - GTFS_URL=${GTFS_URL:-https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip}
 
     volumes:
       # Share the host's `bundle` directory


### PR DESCRIPTION
The hardcoded `GTFS_URL=value` syntax always set a literal value, overriding any host environment variable. Switch to `${GTFS_URL:-default}` interpolation so the host's GTFS_URL is used when set, falling back to the Unitrans default otherwise.

Fixes #120.